### PR TITLE
Add resource limits to metrics-server

### DIFF
--- a/applications/wave-00-init/metrics-server.yaml
+++ b/applications/wave-00-init/metrics-server.yaml
@@ -28,3 +28,10 @@ spec:
         values: |
           args:
             - --kubelet-insecure-tls
+          resources:
+            requests:
+              cpu: 50m
+              memory: 50Mi
+            limits:
+              cpu: 200m
+              memory: 100Mi


### PR DESCRIPTION
## Summary

metrics-server had resource requests set by the chart defaults but no limits, leaving it unbounded on this Pi cluster. This adds explicit requests and limits to the Helm values block in the ArgoCD Application manifest.

**Change:** `applications/wave-00-init/metrics-server.yaml`

```yaml
resources:
  requests:
    cpu: 50m
    memory: 50Mi
  limits:
    cpu: 200m
    memory: 100Mi
```

Values are sized conservatively for a low-resource homelab node — consistent with how other wave-00 and observability components are configured in this repo.

## Verification

YAML structure validated via `python3 -c "import yaml; ..."` — the values block parses correctly and the resources keys are in the expected position for the metrics-server Helm chart.

Closes jangroth/homekube#7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qgft373TBDfMwGnjrKhsqk)_