### PR TITLE
Add compact Telegram message template to Alertmanager

### DIFF
--- a/applications/wave-01-apps/kube-prometheus.yaml
+++ b/applications/wave-01-apps/kube-prometheus.yaml
@@ -118,6 +118,7 @@ spec:
             type: NodePort
             nodePort: 30002
           prometheusSpec:
+            externalUrl: http://pi0.taild13083.ts.net:30002
             retention: 15d
             retentionSize: 40GiB
             serviceMonitorSelectorNilUsesHelmValues: false
@@ -167,7 +168,7 @@ spec:
                     message: |-
                       {{ range .Alerts -}}
                       <b>[{{ .Status | toUpper }}]</b> {{ .Labels.alertname }}{{ with .Labels.namespace }} · {{ . }}{{ end }}
-                      {{ with .Annotations.summary }}{{ . }}
+                      {{ with .Annotations.summary }}{{ . | reReplaceAll "&" "&amp;" | reReplaceAll "<" "&lt;" | reReplaceAll ">" "&gt;" }}
                       {{ end -}}<a href="{{ .GeneratorURL }}">View in Prometheus</a>
                       {{ end }}
           service:

--- a/applications/wave-01-apps/kube-prometheus.yaml
+++ b/applications/wave-01-apps/kube-prometheus.yaml
@@ -164,6 +164,12 @@ spec:
                     bot_token_file: /etc/alertmanager/secrets/alertmanager-telegram/bot_token
                     send_resolved: true
                     parse_mode: HTML
+                    message: |-
+                      {{ range .Alerts -}}
+                      <b>[{{ .Status | toUpper }}]</b> {{ .Labels.alertname }}{{ with .Labels.namespace }} · {{ . }}{{ end }}
+                      {{ with .Annotations.summary }}{{ . }}
+                      {{ end -}}<a href="{{ .GeneratorURL }}">View in Prometheus</a>
+                      {{ end }}
           service:
             type: NodePort
             nodePort: 30004


### PR DESCRIPTION
## Problem

The default Alertmanager Telegram receiver dumps every label/annotation plus the full URL-encoded PromQL `generatorURL` per alert. Multi-alert groups regularly exceed Telegram's 4096-character limit, causing delivery failures.

Additionally, with `parse_mode: HTML` active, the raw URL in the text was being auto-linked by Telegram (appearing blue) instead of being rendered as an intentional `<a>` anchor.

## Fix

Add a custom `message` template to the `telegram_configs` block in `applications/wave-01-apps/kube-prometheus.yaml`. The template renders:
- Alert status + name (bold) and namespace
- Summary annotation (if present)
- A proper `<a href="...">View in Prometheus</a>` link (URL hidden in the anchor, not raw text)

This replaces the verbose built-in default with a compact-per-alert layout that stays well within Telegram's limits even for large alert groups.

## Sanity check

- YAML parses cleanly (outer ArgoCD Application manifest and inner Helm values block)
- `kube-prometheus.yaml` is referenced in `applications/kustomization.yaml`

## Verification

Needs a live or synthetic alert (e.g. `amtool alert add`) to confirm the rendered message stays under the length limit and HTML links render correctly in Telegram.

Closes jangroth/homekube#1

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYyHS4X9T4j5rsF9KTU3De)_