### PR TITLE
Add resource requests/limits to observability stack sidecars

### DIFF
--- a/applications/wave-01-apps/alloy.yaml
+++ b/applications/wave-01-apps/alloy.yaml
@@ -33,6 +33,14 @@ spec:
             - key: node-role.kubernetes.io/control-plane
               operator: Exists
               effect: NoSchedule
+          configReloader:
+            resources:
+              requests:
+                memory: 32Mi
+                cpu: 5m
+              limits:
+                memory: 64Mi
+                cpu: 50m
 
         alloy:
           mounts:

--- a/applications/wave-01-apps/kube-prometheus.yaml
+++ b/applications/wave-01-apps/kube-prometheus.yaml
@@ -115,6 +115,22 @@ spec:
             tlsConfig:
               caFile: /etc/prometheus/configmaps/homekube-ca/homekube-ca.crt
               serverName: prometheus-grafana.observability.svc.cluster.local
+          sidecar:
+            resources:
+              requests:
+                memory: 32Mi
+                cpu: 5m
+              limits:
+                memory: 64Mi
+                cpu: 50m
+          downloadDashboards:
+            resources:
+              requests:
+                memory: 32Mi
+                cpu: 5m
+              limits:
+                memory: 64Mi
+                cpu: 50m
 
         prometheus:
           podDisruptionBudget:
@@ -216,3 +232,20 @@ spec:
             limits:
               memory: 256Mi
               cpu: 100m
+
+        prometheusOperator:
+          resources:
+            requests:
+              memory: 128Mi
+              cpu: 10m
+            limits:
+              memory: 256Mi
+              cpu: 200m
+          prometheusConfigReloader:
+            resources:
+              requests:
+                memory: 32Mi
+                cpu: 5m
+              limits:
+                memory: 64Mi
+                cpu: 50m

--- a/applications/wave-01-apps/loki.yaml
+++ b/applications/wave-01-apps/loki.yaml
@@ -104,3 +104,12 @@ spec:
             limits:
               cpu: 50m
               memory: 64Mi
+
+        sidecar:
+          resources:
+            requests:
+              memory: 32Mi
+              cpu: 5m
+            limits:
+              memory: 64Mi
+              cpu: 50m


### PR DESCRIPTION
## Summary

Closes jangroth/homekube#9

Several containers in the `observability` namespace had no resource requests or limits set. This PR fills in the gaps identified in the live cluster audit.

### Changes

**`kube-prometheus.yaml`**
- `prometheusOperator`: add `resources` for the operator container (128Mi/10m → 256Mi/200m)
- `prometheusOperator.prometheusConfigReloader`: add `resources` for the config-reloader sidecar shared by Prometheus and Alertmanager pods (32Mi/5m → 64Mi/50m)
- `grafana.sidecar`: add `resources` covering the `grafana-sc-dashboard` and `grafana-sc-datasources` sidecars (32Mi/5m → 64Mi/50m)
- `grafana.downloadDashboards`: add `resources` for the `download-dashboards` init container (32Mi/5m → 64Mi/50m)

**`loki.yaml`**
- `sidecar`: add `resources` for the `loki-sc-rules` sidecar (32Mi/5m → 64Mi/50m)

**`alloy.yaml`**
- `controller.configReloader`: add `limits` to the config-reloader sidecar, which previously had requests only (→ 64Mi/50m)

All values are sized for low-resource config-watching processes; the operator gets slightly more headroom as a longer-running controller.

## Test plan

- [ ] All YAML files pass `yaml.safe_load_all` (validated in CI / pre-merge)
- [ ] `kustomize build applications/` succeeds on the cluster
- [ ] ArgoCD syncs the updated Applications without error
- [ ] Containers in `observability` namespace show resource limits via `kubectl get pods -n observability -o json`

> **Human review required** — do not auto-merge. Verify resource sizing is appropriate for your Pi cluster before syncing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoQjNutMab1oKWT4kJb7bw)_