### PR TITLE
Fix Grafana TargetDown alert: scrape HTTPS with CA verification

### DIFF
--- a/applications/wave-00-init/cert-manager/grafana-tls.yaml
+++ b/applications/wave-00-init/cert-manager/grafana-tls.yaml
@@ -10,5 +10,7 @@ spec:
   issuerRef:
     name: homekube-ca
     kind: ClusterIssuer
+  dnsNames:
+    - prometheus-grafana.observability.svc.cluster.local
   ipAddresses:
     - 192.168.86.243

--- a/applications/wave-01-apps/kube-prometheus.yaml
+++ b/applications/wave-01-apps/kube-prometheus.yaml
@@ -110,6 +110,11 @@ spec:
               path: /api/health
               port: 3000
               scheme: HTTPS
+          serviceMonitor:
+            scheme: https
+            tlsConfig:
+              caFile: /etc/prometheus/configmaps/homekube-ca/homekube-ca.crt
+              serverName: prometheus-grafana.observability.svc.cluster.local
 
         prometheus:
           podDisruptionBudget:
@@ -122,6 +127,8 @@ spec:
             retention: 15d
             retentionSize: 40GiB
             serviceMonitorSelectorNilUsesHelmValues: false
+            configMaps:
+              - homekube-ca
             storageSpec:
               volumeClaimTemplate:
                 spec:

--- a/applications/wave-01-apps/prometheus-extras/homekube-ca-configmap.yaml
+++ b/applications/wave-01-apps/prometheus-extras/homekube-ca-configmap.yaml
@@ -1,0 +1,20 @@
+# homekube-CA public cert, same PEM as homepage/ca-configmap.yaml.
+# Mounted into Prometheus (spec.configMaps) so it can verify the grafana-tls
+# cert when scraping Grafana's /metrics over HTTPS.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: homekube-ca
+  namespace: observability
+data:
+  homekube-ca.crt: |
+    -----BEGIN CERTIFICATE-----
+    MIIBcDCCARagAwIBAgIUSf9VR+890wUgUZ1h8wCRr6GA7uwwCgYIKoZIzj0EAwIw
+    FjEUMBIGA1UEAxMLaG9tZWt1YmUtY2EwHhcNMjYwNjE3MDQ1MDMyWhcNMzYwNjE0
+    MDQ1MDMyWjAWMRQwEgYDVQQDEwtob21la3ViZS1jYTBZMBMGByqGSM49AgEGCCqG
+    SM49AwEHA0IABPQeFiJdqorOUyttROs9KRaYAijiazWfsBPVVa7xrBgihA/pY3mK
+    Is4OXPgh7XIxFszEj6B3Waq7sVtveJuwGU2jQjBAMA4GA1UdDwEB/wQEAwICpDAP
+    BgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQPA6nWBdIzpaLGXrwAK/7BywHxfzAK
+    BggqhkjOPQQDAgNIADBFAiAqQsWCyR89x9zOhJ+2gWEBDEcWRVkcfc+rYYuPVQDo
+    cgIhAPoIHcIx/+8VDaNFmE7EtKWzB9EcqE+nTpdwX/tcwIqv
+    -----END CERTIFICATE-----


### PR DESCRIPTION
## Summary
- Grafana switched to serving TLS on port 3000 (`grafana.ini.server.protocol: https`), but its `ServiceMonitor` was never updated off the default `scheme: http` — every 30s scrape hit the TLS listener with plaintext and got bounced with a 400, firing `TargetDown` (13 Jul 5:16pm, 14 Jul 5:21am).
- Adds a DNS SAN (`prometheus-grafana.observability.svc.cluster.local`) to the `grafana-tls` Certificate, mounts the cluster CA (`homekube-ca`) into Prometheus, and switches the ServiceMonitor to `scheme: https` with proper CA verification (`caFile` + `serverName`) instead of `insecureSkipVerify`.

## Test plan
- [ ] Confirm `grafana-tls` cert is reissued with the new DNS SAN after ArgoCD syncs
- [ ] Confirm Prometheus target for `prometheus-grafana` shows `health: up`, empty `lastError`, `scrapeUrl` starting with `https://`
- [ ] Confirm `TargetDown` alert clears in Alertmanager

🤖 Generated with [Claude Code](https://claude.com/claude-code)