### PR TITLE
Add resource requests/limits to Longhorn components

### DIFF
--- a/applications/wave-00-init/longhorn.yaml
+++ b/applications/wave-00-init/longhorn.yaml
@@ -26,8 +26,18 @@ spec:
       values: |
         preUpgradeChecker:
           jobEnabled: false
+        longhornManager:
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "1Gi"
         defaultSettings:
           defaultDataPath: "/storage"
           defaultReplicaCount: 2
+          systemManagedCSIComponentsResourceLimits: >-
+            {"csi-attacher":{"requests":{"cpu":"25m","memory":"32Mi"},"limits":{"cpu":"50m","memory":"64Mi"}},"csi-provisioner":{"requests":{"cpu":"25m","memory":"32Mi"},"limits":{"cpu":"50m","memory":"64Mi"}},"csi-resizer":{"requests":{"cpu":"25m","memory":"32Mi"},"limits":{"cpu":"50m","memory":"64Mi"}},"csi-snapshotter":{"requests":{"cpu":"25m","memory":"32Mi"},"limits":{"cpu":"50m","memory":"64Mi"}},"longhorn-csi-plugin":{"requests":{"cpu":"50m","memory":"64Mi"},"limits":{"cpu":"100m","memory":"128Mi"}},"node-driver-registrar":{"requests":{"cpu":"10m","memory":"16Mi"},"limits":{"cpu":"25m","memory":"32Mi"}},"longhorn-liveness-probe":{"requests":{"cpu":"10m","memory":"16Mi"},"limits":{"cpu":"25m","memory":"32Mi"}}}
         persistence:
           defaultClassReplicaCount: 2


### PR DESCRIPTION
## Summary

- Sets `longhornManager.resources` for the longhorn-manager DaemonSet: 200m/256Mi requests → 500m/1Gi limits
- Adds `defaultSettings.systemManagedCSIComponentsResourceLimits` (JSON) for all seven system-managed CSI components: `csi-attacher`, `csi-provisioner`, `csi-resizer`, `csi-snapshotter`, `longhorn-csi-plugin`, `node-driver-registrar`, `longhorn-liveness-probe`; sized at 25m/32Mi → 50m/64Mi for the stateless config-watchers and 50m/64Mi → 100m/128Mi for the CSI plugin

## Limitations

The following Longhorn containers listed in the issue cannot be addressed via Helm chart values in v1.11.2:
- `longhorn-driver-deployer`, `longhorn-ui`, `engine-image-ei-*` — no exposed `resources` field in the chart
- `instance-manager` — CPU is governed by `defaultSettings.guaranteedInstanceManagerCPU` (a per-node percentage, not k8s resource limits); memory limits are not chart-configurable

## Test plan

- [ ] `kustomize build applications/` succeeds (or ArgoCD dry-run passes)
- [ ] ArgoCD syncs the updated Application without error; CSI components restart briefly and return Running
- [ ] `kubectl get pods -n longhorn-system -o json | jq '.items[].spec.containers[].resources'` shows the new requests/limits on manager and CSI pods
- [ ] No Longhorn alerts fire after the rollout

> **Human review required** — do not auto-merge. Verify resource sizing is appropriate for your Pi cluster before syncing (the CSI restart will briefly pause provisioning/attach-detach operations).

Closes jangroth/homekube#8

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1cAHTMnVACy9auovfgspS)_